### PR TITLE
直接检测文件地址&防止Play商店应用列表消失

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -10,10 +10,7 @@ ui_print "--API ${API}"
 ui_print "--PATH ${PERMISSION_PATH}"
 mkdir -p "${PERMISSION_PATH}"
 
-cat > "${PERMISSION_PATH}/services.cn.google.xml" <<EOF
+cat >"${PERMISSION_PATH}/services.cn.google.xml" <<EOF
 <?xml version="1.0" encoding="utf-8"?>
 <!-- This is the standard set of features for devices that support the CN GMSCore. -->
-<permissions>
-    <feature name="com.google.android.feature.services_updater" />
-</permissions>
 EOF

--- a/customize.sh
+++ b/customize.sh
@@ -1,7 +1,9 @@
-if [[ ${API} -ge 29 ]]; then
+if [ -f "/system/product/etc/permissions/services.cn.google.xml" ]; then
     PERMISSION_PATH="${MODPATH}/system/product/etc/permissions"
-else
+elif [ -f "/system/etc/permissions/services.cn.google.xml" ]; then
     PERMISSION_PATH="${MODPATH}/system/etc/permissions"
+else
+    abort "services.cn.google.xml Not found!"
 fi
 
 ui_print "--API ${API}"


### PR DESCRIPTION
* 直接检测文件地址（一加 氢 OS Android 10 还放在 `/system/etc/permissions/`）
* 防止Play商店无法获取本机已从Play安装的应用 
---
坏掉的例子
![image](https://user-images.githubusercontent.com/40033067/122051699-78baa680-ce17-11eb-843f-19fea01ddf6f.png)
![image](https://user-images.githubusercontent.com/40033067/122051707-7c4e2d80-ce17-11eb-9243-b7e260cd15c7.png)
